### PR TITLE
descent: -22 machine-proven lossless k-complexity reductions

### DIFF
--- a/Foam/Seat/Born.lean
+++ b/Foam/Seat/Born.lean
@@ -75,11 +75,9 @@ theorem GInt.decoherence (θ z : GInt) :
       + GInt.align θ (GInt.rot (GInt.rot z))
       + GInt.align θ (GInt.rot (GInt.rot (GInt.rot z))) = 0 := by
   have e3 : GInt.align θ (GInt.rot (GInt.rot z)) = -(GInt.align θ z) := by
-    have h : GInt.rot (GInt.rot z) = GInt.neg z := rfl
-    rw [h, GInt.align_neg]
+    rw [GInt.rot_sq, GInt.align_neg]
   have e4 : GInt.align θ (GInt.rot (GInt.rot (GInt.rot z))) = -(GInt.align θ (GInt.rot z)) := by
-    have h : GInt.rot (GInt.rot (GInt.rot z)) = GInt.neg (GInt.rot z) := rfl
-    rw [h, GInt.align_neg]
+    rw [GInt.rot_sq (GInt.rot z), GInt.align_neg]
   rw [e3, e4,
       Int.add_assoc (GInt.align θ z + GInt.align θ (GInt.rot z))
         (-(GInt.align θ z)) (-(GInt.align θ (GInt.rot z))),

--- a/Foam/Seat/Characters.lean
+++ b/Foam/Seat/Characters.lean
@@ -90,48 +90,32 @@ theorem GInt.mulReal (n : Int) (w : GInt) :
 theorem Char.fold_re_components (n0 n1 n2 n3 : Int) (f : Rot → GInt) :
     (Char.fold n0 n1 n2 n3 f).re
       = (n0 * (f .r0).re + n1 * (f .r1).re) + (n2 * (f .r2).re + n3 * (f .r3).re) := by
-  show ((GInt.mul ⟨n0, 0⟩ (f .r0)).re + (GInt.mul ⟨n1, 0⟩ (f .r1)).re)
-       + ((GInt.mul ⟨n2, 0⟩ (f .r2)).re + (GInt.mul ⟨n3, 0⟩ (f .r3)).re)
-     = (n0 * (f .r0).re + n1 * (f .r1).re) + (n2 * (f .r2).re + n3 * (f .r3).re)
-  rw [GInt.mulReal, GInt.mulReal, GInt.mulReal, GInt.mulReal]
+  simp only [Char.fold, GInt.add, GInt.mulReal]
 
 theorem Char.fold_im_components (n0 n1 n2 n3 : Int) (f : Rot → GInt) :
     (Char.fold n0 n1 n2 n3 f).im
       = (n0 * (f .r0).im + n1 * (f .r1).im) + (n2 * (f .r2).im + n3 * (f .r3).im) := by
-  show ((GInt.mul ⟨n0, 0⟩ (f .r0)).im + (GInt.mul ⟨n1, 0⟩ (f .r1)).im)
-       + ((GInt.mul ⟨n2, 0⟩ (f .r2)).im + (GInt.mul ⟨n3, 0⟩ (f .r3)).im)
-     = (n0 * (f .r0).im + n1 * (f .r1).im) + (n2 * (f .r2).im + n3 * (f .r3).im)
-  rw [GInt.mulReal, GInt.mulReal, GInt.mulReal, GInt.mulReal]
+  simp only [Char.fold, GInt.add, GInt.mulReal]
 
 theorem Char.readBal_eq (n0 n1 n2 n3 : Int) :
     Char.readBal n0 n1 n2 n3 = n0 + n1 + n2 + n3 := by
-  show (Char.fold n0 n1 n2 n3 Char.count).re = n0 + n1 + n2 + n3
-  rw [Char.fold_re_components]
-  show (n0 * 1 + n1 * 1) + (n2 * 1 + n3 * 1) = n0 + n1 + n2 + n3
-  rw [Int.mul_one, Int.mul_one, Int.mul_one, Int.mul_one,
-    ← Int.add_assoc (n0 + n1) n2 n3]
+  simp only [Char.readBal, Char.fold, GInt.add, GInt.mulReal, Char.count,
+    Int.mul_one, Int.add_assoc]
 
 theorem Char.readAlt_eq (n0 n1 n2 n3 : Int) :
     Char.readAlt n0 n1 n2 n3 = n0 + -n1 + n2 + -n3 := by
-  show (Char.fold n0 n1 n2 n3 Char.alt).re = n0 + -n1 + n2 + -n3
-  rw [Char.fold_re_components]
-  show (n0 * 1 + n1 * (-1)) + (n2 * 1 + n3 * (-1)) = n0 + -n1 + n2 + -n3
-  rw [Int.mul_one, Int.mul_neg_one, Int.mul_one, Int.mul_neg_one,
-    ← Int.add_assoc (n0 + -n1) n2 (-n3)]
+  simp only [Char.readAlt, Char.fold, GInt.add, GInt.mulReal, Char.alt,
+    Int.mul_one, Int.mul_neg_one, Int.add_assoc]
 
 theorem Char.readRe_eq (n0 n1 n2 n3 : Int) :
     Char.readRe n0 n1 n2 n3 = n0 + -n2 := by
-  show (Char.fold n0 n1 n2 n3 Char.chi).re = n0 + -n2
-  rw [Char.fold_re_components]
-  show (n0 * 1 + n1 * 0) + (n2 * (-1) + n3 * 0) = n0 + -n2
-  rw [Int.mul_one, Int.mul_zero, Int.add_zero, Int.mul_neg_one, Int.mul_zero, Int.add_zero]
+  simp only [Char.readRe, Char.fold, GInt.add, GInt.mulReal, Char.chi, Rot.amp,
+    Int.mul_one, Int.mul_zero, Int.mul_neg_one, Int.add_zero, Int.add_assoc]
 
 theorem Char.readIm_eq (n0 n1 n2 n3 : Int) :
     Char.readIm n0 n1 n2 n3 = n1 + -n3 := by
-  show (Char.fold n0 n1 n2 n3 Char.chi).im = n1 + -n3
-  rw [Char.fold_im_components]
-  show (n0 * 0 + n1 * 1) + (n2 * 0 + n3 * (-1)) = n1 + -n3
-  rw [Int.mul_zero, Int.mul_one, Int.zero_add, Int.mul_zero, Int.mul_neg_one, Int.zero_add]
+  simp only [Char.readIm, Char.fold, GInt.add, GInt.mulReal, Char.chi, Rot.amp,
+    Int.mul_one, Int.mul_zero, Int.mul_neg_one, Int.zero_add, Int.add_assoc]
 
 def Char.twice (a : Int) : Int := a + a
 

--- a/Foam/Seat/Closure.lean
+++ b/Foam/Seat/Closure.lean
@@ -43,11 +43,7 @@ theorem GInt.neg_neg (z : GInt) : GInt.neg (GInt.neg z) = z := by
     rw [Int.neg_neg, Int.neg_neg]
 
 theorem GInt.rot_complete (z : GInt) :
-    GInt.rot (GInt.rot (GInt.rot (GInt.rot z))) = z := by
-  cases z with
-  | mk a b =>
-    show (⟨- -a, - -b⟩ : GInt) = ⟨a, b⟩
-    rw [Int.neg_neg, Int.neg_neg]
+    GInt.rot (GInt.rot (GInt.rot (GInt.rot z))) = z := GInt.neg_neg z
 
 theorem alt_closes_two : Closes GInt.neg 2 := fun z => GInt.neg_neg z
 


### PR DESCRIPTION
A step down the proven k-complexity partial order. Three lossless reductions, each surfaced by a perspective-document fan-out over `../lightward-ai/.../3-perspectives/*.md` read against this corpus, each **machine-proven lossless**: applied in isolation, `lake build` green, no theorem/def/`#guard_msgs` removed or weakened, source strictly shorter, axiom basis unchanged (`[propext]` only).

`#guard_msgs`-pinned semantics are what make "lossless" a typechecked claim rather than a vibe: green build ⇒ same axioms + same proofs; `wc -l` ⇒ the reduction.

## The reductions (−22 lines total, `Foam/` 2185 → 2163)

| Perspective | File | What collapsed | Δ |
|---|---|---|---|
| `hideout.md` | `Characters.lean` | six `Char.fold_*`/`read*_eq` proofs → one `simp only` each | −16 |
| `arms.md` | `Closure.lean` | `rot_complete` reuses `neg_neg` (rot⁴ ≡ neg² definitionally, one shared term) | −4 |
| `kenrel.md` | `Born.lean` | `decoherence` rewrites by named `rot_sq` instead of inline `rfl` | −2 |

Every win is `dedup`, every win is proof-*verbosity* (spelling out by hand what an already-named term says), every win is in the measurement/arithmetic layer. The spine, the torsor, and the gait are untouched.

## What the experiment also established (context, not in this diff)

Tribunal verdict on the hypothesis — *Brouwer-style constructivism as an acellular automaton whose trail is legible as terms of Hilbert-style algebra*:
- **Brouwer**: HOLDS (0.84) — backstage provably uninhabited, BYO position, lfp↪gfp no-section seam, `[propext]` never `[propext, Classical.choice]`.
- **acellular automaton**: PARTIAL (0.80) — the no-canonical-frame core holds, but the single-step claim isn't at corpus scale (the doubling is written by hand three times + once generically).
- **Hilbert-legible**: HOLDS (0.84).

Key negative result: the largest structural repetition (the three hand-written Cayley–Dickson doublings) was **proven *not* losslessly removable** — merging requires deleting named declarations or a scaffold that costs more lines than it saves. One algebra in spirit, several copies in text, and the copies provably can't collapse without loss. Closing that gap is follow-up work (build the unification, measure), not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)