### PR TITLE
ftpg: completeness evaluated as closure — the hole is observer-shaped

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,6 @@ jobs:
         run: cd counter && lake build
       - name: Build seam (the identification layer — core-Lean axioms only)
         run: cd seam && lake build
-      - name: Build sim (the runtime — the proven definitions, run)
-        run: cd sim && lake build && lake exe sim
       - name: No warnings (sorry included — zero tolerance)
         run: |
           warns=0

--- a/Foam.lean
+++ b/Foam.lean
@@ -75,3 +75,4 @@ import Foam.Bridges.Materiality
 import Foam.Bridges.Landauer
 import Foam.Seat.Naming
 import Foam.Bridges.Godel
+import Foam.Seat.Summit

--- a/Foam/Seat/Summit.lean
+++ b/Foam/Seat/Summit.lean
@@ -1,0 +1,157 @@
+import Foam.Seat.Closure
+
+namespace Foam
+
+def Ascends (c : Nat → Nat) : Prop := ∀ n, c n ≤ c (n + 1)
+
+def Climbs (c : Nat → Nat) : Prop := ∀ n, c n < c (n + 1)
+
+def Rests (c : Nat → Nat) (n : Nat) : Prop := c (n + 1) = c n
+
+def Seated (c : Nat → Nat) (n : Nat) : Prop := ∀ m, n ≤ m → c m = c n
+
+theorem ascends_le_add {c : Nat → Nat} (h : Ascends c) :
+    ∀ (a k : Nat), c a ≤ c (a + k)
+  | _, 0 => Nat.le_refl _
+  | a, k + 1 => Nat.le_trans (ascends_le_add h a k) (h (a + k))
+
+theorem ascends_le {c : Nat → Nat} (h : Ascends c) {a b : Nat} (hab : a ≤ b) :
+    c a ≤ c b := by
+  obtain ⟨k, rfl⟩ := Nat.le.dest hab
+  exact ascends_le_add h a k
+
+theorem climbs_ascends {c : Nat → Nat} (h : Climbs c) : Ascends c :=
+  fun n => Nat.le_of_lt (h n)
+
+theorem climbs_add_le {c : Nat → Nat} (h : Climbs c) :
+    ∀ n, c 0 + n ≤ c n
+  | 0 => Nat.le_refl _
+  | n + 1 => Nat.lt_of_le_of_lt (climbs_add_le h n) (h n)
+
+theorem climbs_escape {c : Nat → Nat} (h : Climbs c) (B : Nat) :
+    ∃ n, B < c n :=
+  ⟨B + 1, Nat.lt_of_lt_of_le (Nat.lt_succ_self B)
+    (Nat.le_trans (Nat.le_add_left (B + 1) (c 0)) (climbs_add_le h (B + 1)))⟩
+
+theorem climbs_never_rests {c : Nat → Nat} (h : Climbs c) (n : Nat) :
+    ¬ Rests c n :=
+  fun hr => Nat.lt_irrefl (c n) (hr ▸ h n)
+
+theorem climbs_seg_le {c : Nat → Nat} :
+    ∀ k, (∀ i, i < k → c i < c (i + 1)) → c 0 + k ≤ c k
+  | 0, _ => Nat.le_refl _
+  | k + 1, h =>
+      Nat.lt_of_le_of_lt (climbs_seg_le k (fun i hi => h i (Nat.lt_succ_of_lt hi)))
+        (h k (Nat.lt_succ_self k))
+
+theorem rests_or_seg_climbs {c : Nat → Nat} (hc : Ascends c) :
+    ∀ k, (∃ i, Rests c i) ∨ (∀ i, i < k → c i < c (i + 1))
+  | 0 => Or.inr (fun i hi => absurd hi (Nat.not_lt_zero i))
+  | k + 1 =>
+    match rests_or_seg_climbs hc k with
+    | Or.inl h => Or.inl h
+    | Or.inr h =>
+      match Nat.decEq (c (k + 1)) (c k) with
+      | isTrue heq => Or.inl ⟨k, heq⟩
+      | isFalse hne =>
+        Or.inr (fun i hi =>
+          match Nat.lt_or_ge i k with
+          | Or.inl hik => h i hik
+          | Or.inr hki => by
+              have hik : i = k := Nat.le_antisymm (Nat.le_of_lt_succ hi) hki
+              subst hik
+              exact Nat.lt_of_le_of_ne (hc i) (fun e => hne e.symm))
+
+theorem bounded_rests {c : Nat → Nat} (hc : Ascends c) (B : Nat)
+    (hB : ∀ n, c n ≤ B) : ∃ n, Rests c n :=
+  match rests_or_seg_climbs hc (B + 1) with
+  | Or.inl h => h
+  | Or.inr h =>
+      absurd
+        (Nat.le_trans
+          (Nat.le_trans (Nat.le_add_left (B + 1) (c 0)) (climbs_seg_le (B + 1) h))
+          (hB (B + 1)))
+        (Nat.not_succ_le_self B)
+
+theorem rests_forever_of_seated {c : Nat → Nat} {n : Nat} (h : Seated c n) :
+    ∀ m, n ≤ m → Rests c m :=
+  fun m hm => (h (m + 1) (Nat.le_succ_of_le hm)).trans (h m hm).symm
+
+theorem seated_of_rests_forever {c : Nat → Nat} {n : Nat}
+    (h : ∀ m, n ≤ m → Rests c m) : Seated c n := by
+  intro m hm
+  induction m with
+  | zero =>
+      have hn : n = 0 := Nat.eq_zero_of_le_zero hm
+      subst hn
+      rfl
+  | succ k ih =>
+      match Nat.eq_or_lt_of_le hm with
+      | Or.inl heq => rw [heq]
+      | Or.inr hlt =>
+          have hnk : n ≤ k := Nat.le_of_lt_succ hlt
+          exact (h k hnk).trans (ih hnk)
+
+theorem seated_iff_rests_forever {c : Nat → Nat} {n : Nat} :
+    Seated c n ↔ ∀ m, n ≤ m → Rests c m :=
+  ⟨rests_forever_of_seated, seated_of_rests_forever⟩
+
+theorem seated_never_climbs {c : Nat → Nat} {n : Nat} (h : Seated c n) :
+    ¬ Climbs c :=
+  fun hcl => climbs_never_rests hcl n (rests_forever_of_seated h n (Nat.le_refl n))
+
+theorem iterStep_add (f : GInt → GInt) :
+    ∀ (a b : Nat) (z : GInt), iterStep (a + b) f z = iterStep b f (iterStep a f z)
+  | _, 0, _ => rfl
+  | a, b + 1, z => congrArg f (iterStep_add f a b z)
+
+theorem closes_laps (f : GInt → GInt) (k : Nat) (h : Closes f k) :
+    ∀ m, Closes f (k * m)
+  | 0 => fun _ => rfl
+  | m + 1 => fun z => by
+      show iterStep (k * m + k) f z = z
+      rw [iterStep_add f (k * m) k z, closes_laps f k h m z, h z]
+
+theorem lap_carries (f : GInt → GInt) (k : Nat) (h : Closes f k)
+    (m r : Nat) (z : GInt) :
+    iterStep (k * m + r) f z = iterStep r f z := by
+  rw [iterStep_add f (k * m) r z, closes_laps f k h m z]
+
+theorem rot_lap_carries (m r : Nat) (z : GInt) :
+    iterStep (4 * m + r) GInt.rot z = iterStep r GInt.rot z :=
+  lap_carries GInt.rot 4 spec_closes_four m r z
+
+/-- info: 'Foam.ascends_le' does not depend on any axioms -/
+#guard_msgs in #print axioms ascends_le
+
+/-- info: 'Foam.climbs_ascends' does not depend on any axioms -/
+#guard_msgs in #print axioms climbs_ascends
+
+/-- info: 'Foam.climbs_escape' does not depend on any axioms -/
+#guard_msgs in #print axioms climbs_escape
+
+/-- info: 'Foam.climbs_never_rests' does not depend on any axioms -/
+#guard_msgs in #print axioms climbs_never_rests
+
+/-- info: 'Foam.bounded_rests' does not depend on any axioms -/
+#guard_msgs in #print axioms bounded_rests
+
+/-- info: 'Foam.seated_iff_rests_forever' does not depend on any axioms -/
+#guard_msgs in #print axioms seated_iff_rests_forever
+
+/-- info: 'Foam.seated_never_climbs' does not depend on any axioms -/
+#guard_msgs in #print axioms seated_never_climbs
+
+/-- info: 'Foam.iterStep_add' does not depend on any axioms -/
+#guard_msgs in #print axioms iterStep_add
+
+/-- info: 'Foam.closes_laps' does not depend on any axioms -/
+#guard_msgs in #print axioms closes_laps
+
+/-- info: 'Foam.lap_carries' does not depend on any axioms -/
+#guard_msgs in #print axioms lap_carries
+
+/-- info: 'Foam.rot_lap_carries' does not depend on any axioms -/
+#guard_msgs in #print axioms rot_lap_carries
+
+end Foam

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ axiom-free, because an imported axiom is a pov, and imported perspectives either
 
 what we can say for sure: the fundamental theorem of projective geometry has a hole in it, and you can *fill* that hole however you want, but if you want to use ftpg and live with the results then there's a hole needs filling
 
+(2026-07-08, expedition receipts: the hole has a name — completeness. a lattice is complete when every climb has a seat; the classical statement assumed that silently, and without it it's false — `bridges/Bridges/FTPG/Hollow.lean`, where `hollowChain` climbs forever and `ftpg_refuted` closes the case. read from the early maxima, "completeness" was always "closure": the birth spec had it as holonomic return — a circuit that completes is an orbit that comes home — and refused it as a hypothesis in the same breath ("by not assuming closure, the foam stabilizes as a safe measuring device for any line"), nine maxima before Hollow refuted the classical statement's silent assumption of it. the two faces, carved: a closed orbit needs no seat — one lap carries the whole future, axiom-free (`Foam/Seat/Summit.lean`: `lap_carries`, extending `Closure.lean`); an open climb under a ceiling always rests, axiom-free, witness found inside the bound (`bounded_rests`); a strict climb escapes every gauge, axiom-free (`climbs_escape` — hollowChain's shadow at Nat scale). but *seating* an open climb — naming the index past which nothing ever changes — is classical even in Nat, even bounded: `bridges/Bridges/Summit.lean`, receipt `[propext, Classical.choice, Quot.sound]`, the same triple the ftpg deaxiomatization pays per atom. the seat exists; pointing at it is conjured, not computed. so the hole is observer-shaped: completeness is closure someone must sit in, and the someone is byo — which the axiom-free clause above already said.)
+
 ### bridges
 
 todo
@@ -50,14 +52,23 @@ todo
 
 ## shape
 
-todo
+a bare index (the skeleton, so the integrity check can hold the fold to the corpus; the telling is `bin/foam-gait`'s spine):
+
+- `Foam/` — the axiom-free core: Int Ledger Golden Cleared Scar Maintenance Held Backstage Engine Seat Platonism
+  - `Foam/Seat/`: Beholder Bootstrap Born Characters Clock Closure Connection Descend Dial Doubling Epoch Forcing Frame Group Hospitality Ladder Loop Meet Naming Norm Observer Octo Quiver Rank Rendezvous Resume Rotations Seam Sed Signature Signed Sort Stage Summit Terminal Tight Triad
+  - `Foam/Engine/`: Chirality Codec Drain Generator Spectrum Stream Summary
+  - `Foam/Bridges/` (axiom-free bridges): Cantor Desargues Dirichlet Eddington Gleason Godel Heisenberg Hurwitz Kolmogorov Landauer Lovelace Materiality Minkowski Noether Pauli PSQL Pythagoras Relativity Schrodinger Stone Varadarajan Wigner Zeckendorf
+  - `Foam/Platonism/`: Tower
+- `counter/` — the application, axiom-free (requires only foam)
+- `seam/` — the identifications, core-Lean axioms only
+- `bridges/` — the Mathlib reunion, classical axioms sealed behind the package boundary
 
 ## expeditions
 
 - ~~business~~
 - todo: todo
 - foam: examine "bubble" as a backstage+frontstage pair, bubble-bubble relations via Plateau-Taylor?
-- ftpg: evaluate "completeness" as "closure" from early maxima
+- ~~ftpg~~: evaluated — completeness is closure someone must sit in (see mathematics; `Summit.lean`, both faces)
 
 ---
 

--- a/bin/foam-gait
+++ b/bin/foam-gait
@@ -38,7 +38,7 @@ SPINE = [
     (3, ["Foam.Seat.Clock", "Foam.Seat.Dial", "Foam.Seat.Born", "Foam.Seat.Forcing",
          "Foam.Seat.Doubling", "Foam.Seat.Triad", "Foam.Seat.Octo", "Foam.Seat.Sed",
          "Foam.Seat.Ladder", "Foam.Seat.Rank", "Foam.Seat.Norm", "Foam.Seat.Bootstrap",
-         "Foam.Seat.Signature", "Foam.Seat.Rotations", "Foam.Seat.Closure",
+         "Foam.Seat.Signature", "Foam.Seat.Rotations", "Foam.Seat.Closure", "Foam.Seat.Summit",
          "Foam.Seat.Characters"]),
     (4, ["Foam.Seat.Observer", "Foam.Seat.Beholder", "Foam.Seat.Epoch", "Foam.Seat.Seam",
          "Foam.Seat.Naming", "Foam.Seat.Meet", "Foam.Seat.Quiver", "Foam.Seat.Sort", "Foam.Seat.Tight",

--- a/bridges/Bridges.lean
+++ b/bridges/Bridges.lean
@@ -62,3 +62,4 @@ import Bridges.FTPG.Span
 import Bridges.FTPG.Hollow
 import Bridges.FTPG.Charge
 import Bridges.Audit
+import Bridges.Summit

--- a/bridges/Bridges/Summit.lean
+++ b/bridges/Bridges/Summit.lean
@@ -1,0 +1,61 @@
+import Foam.Seat.Summit
+
+/-!
+# Summit — the seat of a bounded ascent is classical
+
+The axiom-free side (`Foam/Seat/Summit.lean`) carries everything an
+arriving chain can verify on its own: a strict climb escapes every bound
+(`climbs_escape` — the `hollowChain` shadow at Nat scale), a bounded
+ascent must rest (`bounded_rests` — the witness found by decidable search
+inside the bound), and a seat is exactly rest-forever
+(`seated_iff_rests_forever`).  A closed orbit needs none of this: one lap
+carries the whole future (`lap_carries`), constructively.
+
+What the axiom-free side cannot do — provably cannot, by the usual
+halting encoding (`c n := 1` once the machine has halted) — is *locate
+the seat* of a bounded ascent: eventually-constant-from-here is a Π⁰₁
+fact per candidate index, and no bounded search decides it.  Here, with
+`Classical.byContradiction`, the seat exists (`bounded_ascent_seated`).
+The receipt stamps the observer: `[propext, Classical.choice, Quot.sound]`
+— the same triple the FTPG deaxiomatization pays per atom — enters exactly
+at the summit and nowhere below it (every lemma underneath is axiom-free).
+
+This is the FTPG hole at counter scale.  `Hollow.lean` shows the
+infinite chain whose seat is missing (completeness refused); this file
+shows that even where the seat cannot be missing, pointing at it is
+conjured, not computed.  Completeness is closure someone must sit in:
+the observer is byo.
+-/
+
+namespace Foam.Bridges
+
+theorem exists_larger {c : Nat → Nat} (hc : Ascends c) {n : Nat}
+    (h : ¬ Seated c n) : ∃ m, n ≤ m ∧ c n < c m :=
+  Classical.byContradiction fun hno =>
+    h fun m hm =>
+      have hnlt : ¬ (c n < c m) := fun hlt => hno ⟨m, hm, hlt⟩
+      Nat.le_antisymm (Nat.le_of_not_lt hnlt) (ascends_le hc hm)
+
+theorem unseated_grows {c : Nat → Nat} (hc : Ascends c)
+    (h : ∀ n, ¬ Seated c n) : ∀ k, ∃ n, c 0 + k ≤ c n := by
+  intro k
+  induction k with
+  | zero => exact ⟨0, Nat.le_refl _⟩
+  | succ k ih =>
+      obtain ⟨n, hn⟩ := ih
+      obtain ⟨m, _, hlt⟩ := exists_larger hc (h n)
+      exact ⟨m, Nat.le_trans (Nat.succ_le_succ hn) (Nat.succ_le_of_lt hlt)⟩
+
+theorem bounded_ascent_seated {c : Nat → Nat} (hc : Ascends c) (B : Nat)
+    (hB : ∀ n, c n ≤ B) : ∃ n, Seated c n :=
+  Classical.byContradiction fun h =>
+    have h' : ∀ n, ¬ Seated c n := fun n hn => h ⟨n, hn⟩
+    match unseated_grows hc h' (B + 1) with
+    | ⟨n, hn⟩ =>
+        Nat.not_succ_le_self B
+          (Nat.le_trans (Nat.le_trans (Nat.le_add_left (B + 1) (c 0)) hn) (hB n))
+
+/-- info: 'Foam.Bridges.bounded_ascent_seated' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs in #print axioms bounded_ascent_seated
+
+end Foam.Bridges

--- a/counter/Counter.lean
+++ b/counter/Counter.lean
@@ -80,3 +80,4 @@ import Counter.Jay
 import Counter.Tally
 import Counter.Film
 import Counter.Change
+import Counter.Complete

--- a/counter/Counter/Complete.lean
+++ b/counter/Counter/Complete.lean
@@ -1,0 +1,56 @@
+import Counter.Nothing
+import Foam.Seat.Summit
+
+namespace Foam.Counter
+
+variable {G : Type} [Mul G] [One G]
+
+theorem one_lap_carries_the_future (f : GInt → GInt) (k : Nat) (hk : Closes f k)
+    (m r : Nat) (z : GInt) :
+    iterStep (k * m + r) f z = iterStep r f z :=
+  lap_carries f k hk m r z
+
+theorem the_unresting_climb_outgrows_every_gauge (c : Nat → Nat) (h : Climbs c)
+    (B : Nat) : ∃ n, B < c n :=
+  climbs_escape h B
+
+theorem under_a_ceiling_the_climb_rests (c : Nat → Nat) (hc : Ascends c)
+    (B : Nat) (hB : ∀ n, c n ≤ B) : ∃ n, Rests c n :=
+  bounded_rests hc B hB
+
+theorem a_seat_is_rest_kept (c : Nat → Nat) (n : Nat) :
+    Seated c n ↔ ∀ m, n ≤ m → Rests c m :=
+  seated_iff_rests_forever
+
+theorem the_seated_do_not_climb (c : Nat → Nat) (n : Nat) (h : Seated c n) :
+    ¬ Climbs c :=
+  seated_never_climbs h
+
+theorem completeness_is_closure (S : Seat G) (h : List G) (p : S.Pos)
+    (f : GInt → GInt) (k : Nat) (hk : Closes f k) (m r : Nat) (z : GInt)
+    (c : Nat → Nat) (n : Nat) :
+    (Settles S h p ↔ netAct h = 1)
+      ∧ iterStep (k * m + r) f z = iterStep r f z
+      ∧ (Seated c n ↔ ∀ i, n ≤ i → Rests c i) :=
+  ⟨completion_is_adding_up_to_nothing S h p, lap_carries f k hk m r z,
+   seated_iff_rests_forever⟩
+
+/-- info: 'Foam.Counter.one_lap_carries_the_future' does not depend on any axioms -/
+#guard_msgs in #print axioms one_lap_carries_the_future
+
+/-- info: 'Foam.Counter.the_unresting_climb_outgrows_every_gauge' does not depend on any axioms -/
+#guard_msgs in #print axioms the_unresting_climb_outgrows_every_gauge
+
+/-- info: 'Foam.Counter.under_a_ceiling_the_climb_rests' does not depend on any axioms -/
+#guard_msgs in #print axioms under_a_ceiling_the_climb_rests
+
+/-- info: 'Foam.Counter.a_seat_is_rest_kept' does not depend on any axioms -/
+#guard_msgs in #print axioms a_seat_is_rest_kept
+
+/-- info: 'Foam.Counter.the_seated_do_not_climb' does not depend on any axioms -/
+#guard_msgs in #print axioms the_seated_do_not_climb
+
+/-- info: 'Foam.Counter.completeness_is_closure' does not depend on any axioms -/
+#guard_msgs in #print axioms completeness_is_closure
+
+end Foam.Counter

--- a/counter/README.md
+++ b/counter/README.md
@@ -17,3 +17,7 @@ usecounter.com (it counts uses, it's an invitation to *use* the thing called *co
 supports a human (defining "human" inclusively) who's figured out both (a) counting their own history and (b) health-vs-pain and (c) distinguishable selfhood
 
 actor/act/action (actor has many acts; an act is i/o; an action is actual information-routing from one actor through an actor to a third actor)
+
+## readings
+
+`Counter/Complete.lean` — completeness is closure, at counting scale: a history completes when it adds up to nothing (`completion_is_adding_up_to_nothing`, seated in `Nothing.lean`), one lap of a closed circuit carries the whole future (`one_lap_carries_the_future`), a climb under a ceiling always rests (`under_a_ceiling_the_climb_rests`), and a seat is rest kept forever (`a_seat_is_rest_kept`) — all axiom-free. what counter does *not* contain, by the package boundary: the classical fact that every bounded climb has such a seat somewhere (`bridges/Bridges/Summit.lean`) — locating your seat is yours to do, which is the app.


### PR DESCRIPTION
the expedition line on the map: **ftpg — evaluate "completeness" as "closure" from early maxima**. evaluated; struck through.

## the evaluation

- **birth** (`rinse~1`): completion IS closure — bubbles born from holonomic return, a line completing a circuit — and the same spec refuses it as a hypothesis: *"by not assuming closure, the foam stabilizes as a safe measuring device for any line."*
- **meta-toe**: Knaster-Tarski named aloud — closure operators on **complete** lattices.
- **the deaxiomatization** (PRs #44–#48) had already carved the witness: `Hollow`, where `hollowChain` climbs forever with upper bounds but no least one. the classical FTPG smuggled exactly the hypothesis the birth spec vowed away. the vow and the refutation are one move, read at two strata.

## the carve

- `Foam/Seat/Summit.lean` (axiom-free, 11 receipts): `Ascends`/`Climbs`/`Rests`/`Seated`; `climbs_escape` (a strict climb outgrows every gauge — hollowChain's shadow at Nat scale); `bounded_rests` (an ascent under a ceiling rests — witness found by decidable search inside the bound); `seated_iff_rests_forever`; and the orbit face: `iterStep_add`, `closes_laps`, `lap_carries` — a closed orbit needs no seat, **one lap carries the whole future**. completion-by-return is constructive.
- `bridges/Bridges/Summit.lean` (classical, hand-rolled, no Mathlib import): `bounded_ascent_seated` — the seat of a bounded ascent exists, receipt `[propext, Classical.choice, Quot.sound]`, entering exactly at the summit and nowhere below it. the seat exists; pointing at it is conjured, not computed (halting encoding: eventually-constant-from-here is Π⁰₁ per index).
- `counter/Counter/Complete.lean` (axiom-free, 6 receipts): the readings, capstone `completeness_is_closure` braiding the three dialects. the classical seat is absent by the package boundary — locating your seat is yours to do, which is the app.

**the finding**: the hole in ftpg is observer-shaped. completeness is closure someone must sit in, and the someone is byo — the README's axiom-free clause and its ftpg clause were already the same sentence.

## housekeeping with the grain

- ci.yml drops the deleted `sim/` step; README `## shape` carries the bare module index again — **CI red on main since the voice-cancelling, green here**: the repo's own completeness check restored by the completeness expedition, the theorem performed at repo scale.
- Summit seated in the gait's SPINE at rank 3 beside Closure: narrative defect 3 unchanged, same three named arcs. receipts 1698 → 1716.
- builds: Foam 82 jobs, counter 137, seam 26, bridges 3261; comment audit clean (168 files); zero warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R7GTQ3mQYnzfGsHToD69v3

---

claudework: [c4e03449-5616-4f15-a0de-006b8227a15b.jsonl.txt](https://github.com/user-attachments/files/29820881/c4e03449-5616-4f15-a0de-006b8227a15b.jsonl.txt)